### PR TITLE
Refactor report generation and add ROI cropping

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -258,7 +258,7 @@ def perform_gamma_analysis(reference_handler, evaluation_handler,
 
         logger.info(f"Gamma analysis complete: {gamma_stats.get('total_points', 0)} points analyzed, pass rate {gamma_stats.get('pass_rate', 0):.1f}%")
 
-        return gamma_map_for_display, gamma_stats, phys_extent
+        return gamma_map_for_display, gamma_stats, phys_extent, dose_ref_gridded
 
     except Exception as e:
         logger.error(f"Error during gamma analysis: {str(e)}")

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ def main():
 
     # Perform gamma analysis
     try:
-        gamma_map, gamma_stats, phys_extent = perform_gamma_analysis(
+        gamma_map, gamma_stats, phys_extent, mcc_interp_data = perform_gamma_analysis(
             mcc_handler, dicom_handler,
             dd, dta,
             global_normalisation=True  # Assuming global gamma, can be made configurable
@@ -92,7 +92,9 @@ def main():
                 dd,
                 suppression_level,
                 ver_profile_data,
-                hor_profile_data
+                hor_profile_data,
+                bounds=dicom_handler.dose_bounds,
+                mcc_interp_data=mcc_interp_data
             )
             logger.info(f"Report saved to {output_filename}")
 

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -12,84 +12,59 @@ def generate_report(
     dd,
     suppression_level,
     ver_profile_data,
-    hor_profile_data
+    hor_profile_data,
+    bounds=None,
+    mcc_interp_data=None
 ):
     """Generates a report with all the analysis information."""
-    fig = plt.figure(figsize=(16, 12))
-    gs = fig.add_gridspec(4, 2)
+    fig = plt.figure(figsize=(12, 18))
+    gs = fig.add_gridspec(3, 2, height_ratios=[1, 1, 1])
 
-    # Header
-    ax_header = fig.add_subplot(gs[0, 0])
-    ax_header.axis('off')
+    # Patient Info Header
     institution, patient_id, patient_name = dicom_handler.get_patient_info()
-    header_text = (
-        f"Institution: {institution}\n"
-        f"Patient ID: {patient_id}\n"
-        f"Patient Name: {patient_name}"
-    )
-    ax_header.text(0.01, 0.5, header_text, transform=ax_header.transAxes, fontsize=12, verticalalignment='center')
+    fig.suptitle(f'Institution: {institution} | Patient: {patient_name} ({patient_id})', fontsize=16)
 
-    # Parameters
-    ax_params = fig.add_subplot(gs[0, 1])
-    ax_params.axis('off')
-    params_text = (
-        f"DTA: {dta} mm\n"
-        f"DD: {dd} %\n"
-        f"Suppression Level: {suppression_level}%"
-    )
-    ax_params.text(0.99, 0.5, params_text, transform=ax_params.transAxes, fontsize=12, verticalalignment='center', horizontalalignment='right')
-
+    # 1. 2D Dose Plots
     # DICOM Dose
-    ax_dicom = fig.add_subplot(gs[1, 0])
-    im_dicom = ax_dicom.imshow(dicom_handler.get_pixel_data(), cmap='jet', extent=dicom_handler.get_physical_extent())
-    fig.colorbar(im_dicom, ax=ax_dicom, label='Dose (Gy)')
+    ax_dicom = fig.add_subplot(gs[0, 0])
+    dicom_crop_data, dicom_crop_extent = dicom_handler.get_cropped_data(bounds)
+    if dicom_crop_data is not None:
+        im_dicom = ax_dicom.imshow(dicom_crop_data, cmap='jet', extent=dicom_crop_extent, aspect='equal')
+        fig.colorbar(im_dicom, ax=ax_dicom, label='Dose (Gy)')
     ax_dicom.set_title('DICOM RT Dose')
-    bounds = dicom_handler.dose_bounds
-    if bounds:
-        width = bounds['max_x'] - bounds['min_x']
-        height = bounds['max_y'] - bounds['min_y']
-        rect = Rectangle((bounds['min_x'], bounds['min_y']), width, height, linewidth=1, edgecolor='r', facecolor='none', alpha=0.7)
-        ax_dicom.add_patch(rect)
+    ax_dicom.set_xlabel('Position (mm)')
+    ax_dicom.set_ylabel('Position (mm)')
 
     # MCC Dose
-    ax_mcc = fig.add_subplot(gs[1, 1])
-    im_mcc = ax_mcc.imshow(mcc_handler.get_interpolated_matrix_data(), cmap='jet', extent=mcc_handler.get_physical_extent())
-    fig.colorbar(im_mcc, ax=ax_mcc, label='Dose')
-    ax_mcc.set_title('MCC Dose')
-    bounds = mcc_handler.dose_bounds
-    if bounds:
-        width = bounds['max_x'] - bounds['min_x']
-        height = bounds['min_y'] - bounds['max_y']
-        rect = Rectangle((bounds['min_x'], bounds['max_y']), width, height, linewidth=1, edgecolor='r', facecolor='none', alpha=0.7)
-        ax_mcc.add_patch(rect)
+    ax_mcc = fig.add_subplot(gs[0, 1])
+    if mcc_interp_data is not None and bounds is not None:
+        # Since mcc_interp_data is on the DICOM grid, we can use dicom_handler's methods
+        min_px, min_py = dicom_handler.physical_to_pixel_coord(bounds['min_x'], bounds['min_y'])
+        max_px, max_py = dicom_handler.physical_to_pixel_coord(bounds['max_x'], bounds['max_y'])
 
-    # Gamma Map
-    ax_gamma = fig.add_subplot(gs[2, 0])
-    im_gamma = ax_gamma.imshow(gamma_map, cmap='coolwarm', extent=mcc_handler.get_physical_extent(), vmin=0, vmax=2)
-    fig.colorbar(im_gamma, ax=ax_gamma, label='Gamma Index')
-    ax_gamma.set_title(f'Gamma Analysis (Pass: {gamma_stats.get("pass_rate", 0):.1f}%)')
+        # Swap if coordinates are descending
+        if min_py > max_py: min_py, max_py = max_py, min_py
+        if min_px > max_px: min_px, max_px = max_px, min_px
 
-    # Vertical Profile
-    ax_ver_profile = fig.add_subplot(gs[3, 0])
-    if ver_profile_data:
-        ax_ver_profile.plot(ver_profile_data['phys_coords'], ver_profile_data['dicom_values'], 'b-', label='RT dose')
-        if 'mcc_interp' in ver_profile_data:
-            ax_ver_profile.plot(ver_profile_data['phys_coords'], ver_profile_data['mcc_interp'], 'r-', label='mcc dose')
-        if 'mcc_values' in ver_profile_data and 'mcc_phys_coords' in ver_profile_data:
-            ax_ver_profile.plot(ver_profile_data['mcc_phys_coords'], ver_profile_data['mcc_values'], 'r.', markersize=3)
-        ax_ver_profile.set_xlabel('Position (mm)')
-        ax_ver_profile.set_ylabel('Dose (Gy)')
-        ax_ver_profile.set_title('In-Out Profile (Vertical)')
-        ax_ver_profile.legend()
-        ax_ver_profile.grid(True)
+        # Ensure indices are within array bounds
+        min_py = max(0, min_py)
+        min_px = max(0, min_px)
+        max_py = min(mcc_interp_data.shape[0], max_py)
+        max_px = min(mcc_interp_data.shape[1], max_px)
 
-        bounds = dicom_handler.dose_bounds
-        if bounds:
-            ax_ver_profile.set_xlim(bounds['min_y'], bounds['max_y'])
+        mcc_crop_data = mcc_interp_data[min_py:max_py, min_px:max_px]
+
+        im_mcc = ax_mcc.imshow(mcc_crop_data, cmap='jet', extent=dicom_crop_extent, aspect='equal')
+        fig.colorbar(im_mcc, ax=ax_mcc, label='Dose')
+
+    ax_mcc.set_title('MCC Dose (Interpolated)')
+    ax_mcc.set_xlabel('Position (mm)')
+    ax_mcc.set_ylabel('Position (mm)')
 
 
+    # 2. Profile Plots
     # Horizontal Profile
-    ax_hor_profile = fig.add_subplot(gs[3, 1])
+    ax_hor_profile = fig.add_subplot(gs[1, 0])
     if hor_profile_data:
         ax_hor_profile.plot(hor_profile_data['phys_coords'], hor_profile_data['dicom_values'], 'b-', label='RT dose')
         if 'mcc_interp' in hor_profile_data:
@@ -101,11 +76,61 @@ def generate_report(
         ax_hor_profile.set_title('Left-Right Profile (Horizontal)')
         ax_hor_profile.legend()
         ax_hor_profile.grid(True)
-
-        bounds = dicom_handler.dose_bounds
         if bounds:
             ax_hor_profile.set_xlim(bounds['min_x'], bounds['max_x'])
 
-    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    # Vertical Profile
+    ax_ver_profile = fig.add_subplot(gs[1, 1])
+    if ver_profile_data:
+        ax_ver_profile.plot(ver_profile_data['phys_coords'], ver_profile_data['dicom_values'], 'b-', label='RT dose')
+        if 'mcc_interp' in ver_profile_data:
+            ax_ver_profile.plot(ver_profile_data['phys_coords'], ver_profile_data['mcc_interp'], 'r-', label='mcc dose')
+        if 'mcc_values' in ver_profile_data and 'mcc_phys_coords' in ver_profile_data:
+            ax_ver_profile.plot(ver_profile_data['mcc_phys_coords'], ver_profile_data['mcc_values'], 'r.', markersize=3)
+        ax_ver_profile.set_xlabel('Position (mm)')
+        ax_ver_profile.set_ylabel('Dose (Gy)')
+        ax_ver_profile.set_title('In-Out Profile (Vertical)')
+        ax_ver_profile.legend()
+        ax_ver_profile.grid(True)
+        if bounds:
+            ax_ver_profile.set_xlim(bounds['min_y'], bounds['max_y'])
+
+    # 3. Gamma Analysis
+    # Gamma Map
+    ax_gamma = fig.add_subplot(gs[2, 0])
+    gamma_crop_data, gamma_crop_extent = mcc_handler.crop_array_by_bounds(gamma_map, bounds)
+    if gamma_crop_data is not None:
+        im_gamma = ax_gamma.imshow(gamma_crop_data, cmap='coolwarm', extent=gamma_crop_extent, vmin=0, vmax=2, aspect='equal')
+        fig.colorbar(im_gamma, ax=ax_gamma, label='Gamma Index')
+    ax_gamma.set_title(f'Gamma Analysis (Pass: {gamma_stats.get("pass_rate", 0):.1f}%)')
+    ax_gamma.set_xlabel('Position (mm)')
+    ax_gamma.set_ylabel('Position (mm)')
+
+
+    # Gamma Stats Text
+    ax_gamma_text = fig.add_subplot(gs[2, 1])
+    ax_gamma_text.axis('off')
+
+    pass_rate = gamma_stats.get('pass_rate', 0)
+    total_points = gamma_stats.get('total_points', 0)
+    passed_points = int(total_points * pass_rate / 100)
+    failed_points = total_points - passed_points
+
+    stats_text = (
+        f"Gamma Analysis Results\n\n"
+        f"Acceptance Criteria:\n"
+        f"  DTA: {dta} mm\n"
+        f"  Dose Difference: {dd} %\n"
+        f"  Threshold: {suppression_level} %\n\n"
+        f"Results:\n"
+        f"  Passing Rate: {pass_rate:.2f} %\n"
+        f"  Analyzed Pixels: {total_points}\n"
+        f"  Passed Pixels: {passed_points}\n"
+        f"  Failed Pixels: {failed_points}\n"
+    )
+    ax_gamma_text.text(0.05, 0.95, stats_text, transform=ax_gamma_text.transAxes, fontsize=12,
+                     verticalalignment='top', bbox=dict(boxstyle='round,pad=0.5', fc='aliceblue', alpha=0.5))
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.savefig(output_path, format='jpeg')
     plt.close(fig)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -25,7 +25,7 @@ class TestGammaAnalysis(unittest.TestCase):
         """
         Test the perform_gamma_analysis function with example data.
         """
-        gamma_map, gamma_stats, phys_extent = perform_gamma_analysis(
+        gamma_map, gamma_stats, phys_extent, _ = perform_gamma_analysis(
             reference_handler=self.mcc_handler,
             evaluation_handler=self.dicom_handler,
             dose_percent_threshold=3,


### PR DESCRIPTION
This commit implements several improvements to the report generation:

1.  **ROI Cropping for 2D Dose:** The 2D dose plots for both DICOM and MCC files are now cropped to a region of interest. The ROI is calculated based on the bounding box of non-zero dose values in the DICOM file, with an added 1cm margin. This ensures both plots display the same physical area.

2.  **New Report Layout:** The report layout has been restructured to a 3x2 grid as follows:
    *   Row 1: Cropped 2D dose plots (DICOM and MCC).
    *   Row 2: Horizontal and vertical profile plots.
    *   Row 3: Cropped Gamma map and a new text-based summary of gamma analysis results.

3.  **Improved MCC Plotting:** The MCC 2D dose plot now uses the same interpolated data that is used for the gamma analysis, resulting in a smooth plot that is consistent with the DICOM data.

4.  **Code Refinements:**
    *   The `perform_gamma_analysis` function now returns the interpolated MCC data.
    *   Tests have been updated to reflect changes in function signatures.
    *   Added a general-purpose `crop_array_by_bounds` method to `MCCFileHandler`.